### PR TITLE
fix(ui): Add ghost variant and icon size to Button component

### DIFF
--- a/pelita-ai/src/components/ui/Button.tsx
+++ b/pelita-ai/src/components/ui/Button.tsx
@@ -2,18 +2,26 @@ import React from 'react';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
-  variant?: 'primary' | 'secondary';
+  variant?: 'primary' | 'secondary' | 'ghost';
+  size?: 'default' | 'icon';
 }
 
-export const Button: React.FC<ButtonProps> = ({ children, className = '', variant = 'primary', ...props }) => {
-  const baseStyles = 'px-4 py-2 rounded-md font-semibold focus:outline-none focus:ring-2 focus:ring-offset-2 transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed';
+export const Button: React.FC<ButtonProps> = ({ children, className = '', variant = 'primary', size = 'default', ...props }) => {
+  const baseStyles = 'font-semibold focus:outline-none focus:ring-2 focus:ring-offset-2 transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed';
+
   const variantStyles = {
     primary: 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500',
     secondary: 'bg-gray-200 text-gray-800 hover:bg-gray-300 focus:ring-gray-400',
+    ghost: 'hover:bg-gray-100 text-gray-800 focus:ring-gray-400',
+  };
+
+  const sizeStyles = {
+    default: 'px-4 py-2 rounded-md',
+    icon: 'p-2 rounded-full'
   };
 
   return (
-    <button className={`${baseStyles} ${variantStyles[variant]} ${className}`} {...props}>
+    <button className={`${baseStyles} ${variantStyles[variant]} ${sizeStyles[size]} ${className}`} {...props}>
       {children}
     </button>
   );


### PR DESCRIPTION
- Add 'ghost' to the list of allowed variants in ButtonProps.
- Add 'icon' to the list of allowed sizes.
- Implement styling for the new variant and size.

This resolves a TypeScript error in Header.tsx where the 'ghost' variant was being used but not defined.